### PR TITLE
[2024/07/10] feature/delete-column >> 컬럼 삭제 기능 구현

### DIFF
--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/controller/SectionController.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/controller/SectionController.java
@@ -7,6 +7,7 @@ import com.oeindevelopteam.tasknavigator.global.dto.CommonResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,4 +29,10 @@ public class SectionController {
         .body(new CommonResponseDto(HttpStatus.OK.value(), "컬럼이 생성되었습니다.", responseDto));
   }
 
+  @DeleteMapping("/{columnId}")
+  ResponseEntity<CommonResponseDto> deleteSection(@PathVariable Long boardId, @PathVariable Long columnId) {
+    sectionService.deleteSection(boardId, columnId);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(new CommonResponseDto(HttpStatus.OK.value(), "컬럼이 삭제되었습니다.", null));
+  }
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/entity/Section.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/entity/Section.java
@@ -5,6 +5,7 @@ import com.oeindevelopteam.tasknavigator.domain.card.entity.Card;
 import com.oeindevelopteam.tasknavigator.domain.section.dto.SectionRequestDto;
 import jakarta.persistence.*;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -20,15 +21,17 @@ public class Section {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull(message = "컬럼 순서는 필수입니다.")
     private int sectionOrder;
 
+    @NotNull(message = "컬럼 상태는 필수입니다.")
     private String status;
 
     @ManyToOne
     @JoinColumn(name = "board_id")
     private Board board;
 
-    @OneToMany(mappedBy = "section")
+    @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Card> cards = new ArrayList<>();
 
     public Section(Board board, SectionRequestDto requestDto) {

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/entity/SectionStatus.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/entity/SectionStatus.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -16,6 +17,7 @@ public class SectionStatus {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @NotNull(message = "sectionStatus에 상태값은 필수입니다.")
   private String status;
 
   @ManyToOne

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/repository/SectionStatusRepository.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/repository/SectionStatusRepository.java
@@ -1,9 +1,11 @@
 package com.oeindevelopteam.tasknavigator.domain.section.repository;
 
+import com.oeindevelopteam.tasknavigator.domain.board.entity.Board;
 import com.oeindevelopteam.tasknavigator.domain.section.entity.SectionStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectionStatusRepository extends JpaRepository<SectionStatus, Long> {
   Optional<SectionStatus> findByStatus(String status);
+  Optional<SectionStatus> findByStatusAndBoard(String status, Board board);
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/service/SectionService.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/service/SectionService.java
@@ -31,8 +31,8 @@ public class SectionService {
       throw new CustomException(ErrorCode.DUPLICATE_STATUS);
     }
 
-//    Board board = boardRepository.findById(boardId).orElseThrow(() ->
-//        new CustomException(ErrorCode.BOARD_NOT_FOUND));
+    // 보드 생성과 BoardService에 getBoard가 완료되면 아래 코드로 바꿀 예정
+//    Board board = boardService.getBoard(boardId);
 
     // 보드 생성이 되지 않아 임시로 저장하는 코드
     Board board = new Board("testBoard", "test");
@@ -45,6 +45,22 @@ public class SectionService {
     Section saveSection = sectionRepository.save(newSection);
 
     return new SectionResponseDto(saveSection);
+  }
+
+  @Transactional
+  public void deleteSection(Long boardId, Long columnId) {
+    Section section = sectionRepository.findById(columnId).orElseThrow(() ->
+        new CustomException(ErrorCode.SECTION_NOT_FOUND));
+
+    // TODO: 이 부분 역시 BoardService에 getBoard가 구현되면 바뀔 부분
+    Board board = boardRepository.findById(boardId).orElseThrow(() ->
+        new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+    SectionStatus status = sectionStatusRepository.findByStatusAndBoard(section.getStatus(), board).orElseThrow(() ->
+        new CustomException(ErrorCode.SECTION_STATUS_NOT_FOUND));
+
+    sectionRepository.delete(section);
+    sectionStatusRepository.delete(status);
   }
 
   public Section getSerction(Long sectionId) {

--- a/src/main/java/com/oeindevelopteam/tasknavigator/global/exception/ErrorCode.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
   ROLE_NOT_FOUND(404, "해당 역할을 찾을 수 없습니다."),
   BOARD_NOT_FOUND(404, "해당 보드를 찾을 수 없습니다."),
   SECTION_NOT_FOUND(404, "해당 컬럼을 찾을 수 없습니다."),
+  SECTION_STATUS_NOT_FOUND(404, "해당 컬럼 상태를 찾을 수 없습니다."),
   REQUIRE_BOARD_NAME(404, "보드 이름을 입력해주세요."),
   REQUIRE_BOARD_INFO(404, "한줄 소개를 입력해주세요."),
   DUPLICATE_STATUS(400, "중복된 상태입니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39

## 📝작업 내용

> 컬럼에 대한 삭제 기능을 구현하였습니다.
> Section과 SectionStatus에 notnull을 추가하였습니다.
> 칼럼 삭제 시, 연관된 카드가 삭제되도록 cascade와 orphanRemoval을 추가하였습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b710cba6-5632-4b6d-a0fb-26c7c98e40c4)

## 💬리뷰 요구사항(선택)
