### PR TITLE
[2024/07/12] feature/board >> 보드 목록 조회 기능 오류 수정, DTO타입으로 반환

### DIFF
--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/controller/BoardController.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.oeindevelopteam.tasknavigator.domain.board.controller;
 
+import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardListResponseDto;
 import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardRequestDto;
 import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardResponseDto;
 import com.oeindevelopteam.tasknavigator.domain.board.entity.Board;
@@ -23,9 +24,9 @@ public class BoardController {
     }
 
     @GetMapping("/boards")
-    public ResponseEntity<CommonResponseDto<List<Board>>> getAllBoards(@AuthenticationPrincipal UserDetailsImpl userDetails){
+    public ResponseEntity<CommonResponseDto<List<BoardListResponseDto>>> getAllBoards(@AuthenticationPrincipal UserDetailsImpl userDetails){
 
-        List<Board> boardList = boardService.getAllBoards(userDetails.getUser());
+        List<BoardListResponseDto> boardList = boardService.getAllBoards(userDetails.getUser());
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponseDto<>(HttpStatus.OK.value(), "보드를 조회했습니다.", boardList));
 

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/dto/BoardListResponseDto.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/dto/BoardListResponseDto.java
@@ -1,0 +1,25 @@
+package com.oeindevelopteam.tasknavigator.domain.board.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class BoardListResponseDto {
+
+    private String boardName;
+    private String info;
+    private List<SectionDto> sections; // SectionDto 리스트 필드 추가
+
+    // 매개변수 생성자
+    public BoardListResponseDto(String boardName, String info, List<SectionDto> sections) {
+        this.boardName = boardName;
+        this.info = info;
+        this.sections = sections;
+    }
+
+}

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/dto/CardDto.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/dto/CardDto.java
@@ -1,0 +1,24 @@
+package com.oeindevelopteam.tasknavigator.domain.board.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class CardDto {
+
+    private String title;
+    private String content;
+    private String dueDate;
+    private String manager;
+
+    public CardDto(String title, String content, String dueDate, String manager) {
+        this.title = title;
+        this.content = content;
+        this.dueDate = dueDate;
+        this.manager = manager;
+    }
+
+}

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/dto/SectionDto.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/dto/SectionDto.java
@@ -1,0 +1,24 @@
+package com.oeindevelopteam.tasknavigator.domain.board.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class SectionDto {
+
+    private int sectionOrder;
+    private String status;
+    private List<CardDto> cards; // CardDto 리스트 필드 추가
+
+    public SectionDto(int sectionOrder, String status, List<CardDto> cards) {
+        this.sectionOrder = sectionOrder;
+        this.status = status;
+        this.cards = cards;
+    }
+
+}

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/entity/Board.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/entity/Board.java
@@ -48,4 +48,8 @@ public class Board extends Timestamped {
 
     }
 
+    public void addSectionList(List<Section> sectionList) {
+        this.sectionList = sectionList;
+    }
+
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/repository/UserBoardMatchesRepositoryCustom.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/repository/UserBoardMatchesRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.oeindevelopteam.tasknavigator.domain.board.repository;
 
+import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardListResponseDto;
 import com.oeindevelopteam.tasknavigator.domain.board.entity.Board;
 import org.springframework.stereotype.Repository;
 
@@ -8,7 +9,7 @@ import java.util.List;
 @Repository
 public interface UserBoardMatchesRepositoryCustom {
 
-    List<Board> findBoardByUserId(Long userId);
-    List<Board> findBoard();
+    List<BoardListResponseDto> findBoardByUserId(Long userId);
+    List<BoardListResponseDto> findBoard();
 
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/repository/UserBoardMatchesRepositoryImpl.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/repository/UserBoardMatchesRepositoryImpl.java
@@ -1,12 +1,19 @@
 package com.oeindevelopteam.tasknavigator.domain.board.repository;
 
+import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardListResponseDto;
+import com.oeindevelopteam.tasknavigator.domain.board.dto.CardDto;
+import com.oeindevelopteam.tasknavigator.domain.board.dto.SectionDto;
 import com.oeindevelopteam.tasknavigator.domain.board.entity.Board;
 import com.oeindevelopteam.tasknavigator.domain.board.entity.QBoard;
 import com.oeindevelopteam.tasknavigator.domain.board.entity.QUserBoardMatches;
+import com.oeindevelopteam.tasknavigator.domain.card.entity.Card;
 import com.oeindevelopteam.tasknavigator.domain.card.entity.QCard;
 import com.oeindevelopteam.tasknavigator.domain.section.entity.QSection;
+import com.oeindevelopteam.tasknavigator.domain.section.entity.Section;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -16,36 +23,109 @@ public class UserBoardMatchesRepositoryImpl implements UserBoardMatchesRepositor
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<Board> findBoardByUserId(Long userId){
+    public List<BoardListResponseDto> findBoardByUserId(Long userId){
 
         QUserBoardMatches userBoardMatches = QUserBoardMatches.userBoardMatches;
         QBoard board = QBoard.board;
         QSection section = QSection.section;
         QCard card = QCard.card;
 
-        return jpaQueryFactory.select(board)
+//        return jpaQueryFactory.select(board)
+//                .from(userBoardMatches)
+//                .innerJoin(userBoardMatches.board,board).fetchJoin()
+//                .leftJoin(board.sectionList, section).fetchJoin()
+//                .leftJoin(section.cards, card).fetchJoin()
+//                .where(userBoardMatches.user.id.eq(userId))
+//                .distinct()
+//                .fetch();
+
+        // 보드를 먼저 로드
+        List<Board> boards = jpaQueryFactory.select(board)
                 .from(userBoardMatches)
-                .innerJoin(userBoardMatches.board,board).fetchJoin()
-                .leftJoin(board.sectionList, section).fetchJoin()
-                .leftJoin(section.cards, card).fetchJoin()
+                .innerJoin(userBoardMatches.board,board)
                 .where(userBoardMatches.user.id.eq(userId))
                 .fetch();
 
+        // 각 보드에 대해 섹션과 카드를 별도로 로드
+        for (Board b : boards) {
+            List<Section> sections = jpaQueryFactory.selectFrom(section)
+                    .where(section.board.eq(b))
+                    .orderBy(section.sectionOrder.asc())  // 섹션의 순서를 보장
+                    .fetch();
+            b.addSectionList(sections);
+
+            for (Section s : sections) {
+                List<Card> cards = jpaQueryFactory.selectFrom(card)
+                        .where(card.section.eq(s))
+                        .orderBy(card.id.asc())  // 카드의 순서를 보장
+                        .fetch();
+                s.addCards(cards);
+            }
+        }
+
+        return boards.stream()
+                .map(this::convertToBoardListResponseDto)
+                .collect(Collectors.toList());
     }
 
-    public List<Board> findBoard(){
+    public List<BoardListResponseDto> findBoard(){
 
         QUserBoardMatches userBoardMatches = QUserBoardMatches.userBoardMatches;
         QBoard board = QBoard.board;
         QSection section = QSection.section;
         QCard card = QCard.card;
 
-        return jpaQueryFactory.select(board)
-                .from(userBoardMatches)
-                .innerJoin(userBoardMatches.board,board).fetchJoin()
-                .leftJoin(board.sectionList, section).fetchJoin()
-                .leftJoin(section.cards, card).fetchJoin()
+//        return jpaQueryFactory.select(board)
+//                .from(board)
+//                .leftJoin(board.sectionList, section).fetchJoin()
+//                .leftJoin(section.cards, card).fetchJoin()
+//                .distinct()
+//                .fetch();
+
+        // 보드를 먼저 로드
+        List<Board> boards = jpaQueryFactory.selectFrom(board)
                 .fetch();
 
+        // 각 보드에 대해 섹션과 카드를 별도로 로드
+        for (Board b : boards) {
+            List<Section> sections = jpaQueryFactory.selectFrom(section)
+                    .where(section.board.eq(b))
+                    .orderBy(section.sectionOrder.asc())  // 섹션의 순서를 보장
+                    .fetch();
+            b.addSectionList(sections);
+
+            for (Section s : sections) {
+                List<Card> cards = jpaQueryFactory.selectFrom(card)
+                        .where(card.section.eq(s))
+                        .orderBy(card.id.asc())  // 카드의 순서를 보장
+                        .fetch();
+                s.addCards(cards);
+            }
+        }
+
+        return boards.stream()
+                .map(this::convertToBoardListResponseDto)
+                .collect(Collectors.toList());
     }
+
+    private BoardListResponseDto convertToBoardListResponseDto(Board board) {
+        List<SectionDto> sectionDtos = board.getSectionList().stream()
+                .map(this::convertToSectionDto)
+                .collect(Collectors.toList());
+
+        return new BoardListResponseDto(board.getBoardName(), board.getInfo(), sectionDtos);
+    }
+
+    private SectionDto convertToSectionDto(Section section) {
+        List<CardDto> cardDtos = section.getCards().stream()
+                .map(this::convertToCardDto)
+                .collect(Collectors.toList());
+
+        return new SectionDto(section.getSectionOrder(), section.getStatus(), cardDtos);
+    }
+
+    private CardDto convertToCardDto(Card card) {
+        return new CardDto(card.getTitle(), card.getContent(), card.getDueDate(), card.getManager());
+    }
+
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/service/BoardService.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.oeindevelopteam.tasknavigator.domain.board.service;
 
+import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardListResponseDto;
 import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardRequestDto;
 import com.oeindevelopteam.tasknavigator.domain.board.dto.BoardResponseDto;
 import com.oeindevelopteam.tasknavigator.domain.board.entity.Board;
@@ -42,7 +43,7 @@ public class BoardService {
 
     }
 
-    public List<Board> getAllBoards(User user) {
+    public List<BoardListResponseDto> getAllBoards(User user) {
 
         // userId 로 Board 권한 체크
         List<UserRoleMatches> roles = userRoleMatchesRepository.findByUser(user);

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/entity/Section.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/section/entity/Section.java
@@ -43,4 +43,8 @@ public class Section {
     public void updateOrder(int order) {
         this.sectionOrder = order;
     }
+
+    public void addCards(List<Card> cards) {
+        this.cards = cards;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#19

## 📝작업 내용

> 보드목록 조회가 안되는 오류 수정 (join 분리)
> 리턴타입을 Entity 에서 DTO 로 변경

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/da8cfffd-1a2e-4131-8ac8-b7dfdbf2a238)

## 💬리뷰 요구사항(선택)

> DTO 반환 내용 추가해야하거나, 삭제해야하면 알려주시면 감사하겠습니다
   (아마도 제 생각에는 지금 당장 픽스하기 힘들것같긴 해서 프론트연결할때 한번 더 언급할 것 같습니다)
