### PR TITLE
[2024/07/14] feature/get-cards >> 유저 초대받은 보드 카드 전체 조회, 태그별 조회, 담당자별 조회 기능 구현

### DIFF
--- a/src/main/java/com/oeindevelopteam/tasknavigator/TaskNavigatorApplication.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/TaskNavigatorApplication.java
@@ -2,12 +2,14 @@ package com.oeindevelopteam.tasknavigator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TaskNavigatorApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(TaskNavigatorApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(TaskNavigatorApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/entity/UserBoardMatches.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/entity/UserBoardMatches.java
@@ -3,28 +3,30 @@ package com.oeindevelopteam.tasknavigator.domain.board.entity;
 import com.oeindevelopteam.tasknavigator.domain.user.entity.User;
 import com.oeindevelopteam.tasknavigator.global.entity.Timestamped;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "user_board_matches")
+@Getter
 @NoArgsConstructor
 public class UserBoardMatches extends Timestamped {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id")
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-    @ManyToOne
-    @JoinColumn(name = "board_id", nullable = false)
-    private Board board;
+  @ManyToOne
+  @JoinColumn(name = "board_id", nullable = false)
+  private Board board;
 
-    public UserBoardMatches(User user, Board board) {
-        this.user = user;
-        this.board = board;
-    }
+  public UserBoardMatches(User user, Board board) {
+    this.user = user;
+    this.board = board;
+  }
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/repository/UserBoardMatchesRepository.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/board/repository/UserBoardMatchesRepository.java
@@ -1,12 +1,16 @@
 package com.oeindevelopteam.tasknavigator.domain.board.repository;
 
 import com.oeindevelopteam.tasknavigator.domain.board.entity.UserBoardMatches;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserBoardMatchesRepository extends JpaRepository<UserBoardMatches, Long>, UserBoardMatchesRepositoryCustom {
+public interface UserBoardMatchesRepository extends JpaRepository<UserBoardMatches, Long>,
+    UserBoardMatchesRepositoryCustom {
 
-    Optional<UserBoardMatches> findByBoardIdAndUserId(Long boardId, Long invitedUser);
+  Optional<UserBoardMatches> findByBoardIdAndUserId(Long boardId, Long invitedUser);
+
+  Optional<List<UserBoardMatches>> findByUserId(Long userId);
 
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/controller/CardController.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/controller/CardController.java
@@ -4,17 +4,22 @@ import com.oeindevelopteam.tasknavigator.domain.card.dto.CardRequestDto;
 import com.oeindevelopteam.tasknavigator.domain.card.dto.CardResponseDto;
 import com.oeindevelopteam.tasknavigator.domain.card.dto.CardTagEditRequestDto;
 import com.oeindevelopteam.tasknavigator.domain.card.service.CardService;
+import com.oeindevelopteam.tasknavigator.domain.user.security.UserDetailsImpl;
 import com.oeindevelopteam.tasknavigator.global.dto.CommonResponseDto;
+import com.oeindevelopteam.tasknavigator.global.exception.CustomException;
+import com.oeindevelopteam.tasknavigator.global.exception.ErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,7 +35,7 @@ public class CardController {
     // TODO: 본인이 포함되어 있는 보드인지 확인 필요
     // TODO: ADMIN은 상관없이 통과
 
-    CardResponseDto responseDto = cardService.createdCard(cardRequestDto, columnId);
+    CardResponseDto responseDto = cardService.createdCard(cardRequestDto, boardId, columnId);
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(new CommonResponseDto(200, "카드 생성에 성공하였습니다.", responseDto));
@@ -97,5 +102,31 @@ public class CardController {
         .body(new CommonResponseDto(200, "카드 태그 변경에 성공하였습니다.", responseDto));
 
   }
+
+  @GetMapping("/cards")
+  public ResponseEntity<CommonResponseDto> getCards(
+      @RequestParam(required = false) String tag,
+      @RequestParam(required = false) String manager,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+    List<CardResponseDto> responseDtos;
+
+    // 둘 다 있을 경우 오류 응답 반환
+    if (tag != null && manager != null) {
+      throw new CustomException(ErrorCode.MULTIPLE_PARAMETERS_NOT_ALLOWED);
+    }
+
+    if (tag != null) {
+      responseDtos = cardService.getCardsByTag(tag, userDetails.getUser());
+    } else if (manager != null) {
+      responseDtos = cardService.getCardsByManager(manager, userDetails.getUser());
+    } else {
+      responseDtos = cardService.getAllCardsByInvited(userDetails.getUser());
+    }
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(new CommonResponseDto(200, "카드 조회에 성공하였습니다.", responseDtos));
+  }
+
 
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/dto/CardResponseDto.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/dto/CardResponseDto.java
@@ -10,6 +10,7 @@ public class CardResponseDto {
 
   private Long cardId;
   private Long userId;
+  private Long boardId;
   private Long columnId;
   private String title;
   private String content;
@@ -20,6 +21,7 @@ public class CardResponseDto {
   public CardResponseDto(Card card) {
     this.cardId = card.getId();
     this.userId = card.getUserId();
+    this.boardId = card.getBoardId();
     this.columnId = card.getColumnId();
     this.title = card.getTitle();
     this.content = card.getContent();

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/entity/Card.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/entity/Card.java
@@ -30,6 +30,9 @@ public class Card extends Timestamped {
   private Long userId;
 
   @Column(nullable = false)
+  private Long boardId;
+
+  @Column(nullable = false)
   private Long columnId;
 
   @Column(nullable = false)
@@ -51,8 +54,9 @@ public class Card extends Timestamped {
   @JoinColumn(name = "section_id")
   private Section section;
 
-  public Card(CardRequestDto cardRequestDto, Long columnId, Long userId) {
+  public Card(CardRequestDto cardRequestDto, Long boardId, Long columnId, Long userId) {
     this.userId = userId;
+    this.boardId = boardId;
     this.columnId = columnId;
     this.title = cardRequestDto.getTitle();
     this.content = cardRequestDto.getContent();

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/repository/CardRepository.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/repository/CardRepository.java
@@ -10,4 +10,6 @@ public interface CardRepository extends JpaRepository<Card, Long> {
   List<Card> findAll();
 
   Optional<Card> findById(Long cardId);
+
+  List<Card> findByBoardId(Long boardId);
 }

--- a/src/main/java/com/oeindevelopteam/tasknavigator/global/exception/ErrorCode.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/global/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
   DUPLICATE_STATUS(400, "중복된 상태입니다."),
   ALREADY_HAS_ACCESS(404, "해당 사용자는 이미 권한이 있습니다."),
   ALREADY_EXIST_USER(400, "해당 사용자는 이미 존재합니다."),
-  ALREADY_EXIST_MANAGER(400, "관리자 권한을 가진 사용자가 이미 존재합니다.");
+  ALREADY_EXIST_MANAGER(400, "관리자 권한을 가진 사용자가 이미 존재합니다."),
+  MULTIPLE_PARAMETERS_NOT_ALLOWED(400, "여러 파라미터가 허용되지 않습니다.");
 
   private int status;
   private String message;


### PR DESCRIPTION
## #️⃣연관된 이슈
#16 

## 📝작업 내용
- 초대받은 보드 카드 전체 조회 api, 로직 구현
- 초대받은 보드 카드 태그별 조회 api, 로직 구현
- 초대받은 보드 카드 담당자별 조회 api, 로직 구현
- 카드 entity에 boardId 추가
- 카드 responseDto에 boardId 추가
- 중복되는 cardService로직들 메서드로 분리

### 스크린샷
담당자별 조회
![Pasted Graphic](https://github.com/user-attachments/assets/f73556c5-1e8d-4663-b89f-5a639c7086a9)

태그별 조회
![Pasted Graphic 1](https://github.com/user-attachments/assets/92a9297f-5ed0-45ce-b61e-dacab20ef239)

전체 조회
![Pasted Graphic 2](https://github.com/user-attachments/assets/71ba3620-4ac8-4d22-ba66-1478758df61d)