### PR TITLE
[2024/07/15] feature/set-card-permissions >> 모든 카드 기능 분기처리, role 구분 처리

### DIFF
--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/controller/CardController.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/controller/CardController.java
@@ -41,15 +41,6 @@ public class CardController {
         .body(new CommonResponseDto(200, "카드 생성에 성공하였습니다.", responseDto));
   }
 
-  @GetMapping("/admin/cards")
-  public ResponseEntity<CommonResponseDto> getAllCards() {
-    List<CardResponseDto> responseDtos = cardService.getAllCards();
-
-    // TODO: Admin인지 아닌지 확인하는 로직 필요
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(new CommonResponseDto(200, "전체 카드 조회에 성공하였습니다.", responseDtos));
-  }
-
   @PutMapping("/boards/{boardId}/columns/{columnId}/cards/{cardId}")
   public ResponseEntity<CommonResponseDto> editCardContent(@PathVariable Long boardId,
       @PathVariable Long columnId, @PathVariable Long cardId,

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/controller/CardController.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/controller/CardController.java
@@ -30,12 +30,11 @@ public class CardController {
 
   @PostMapping("/boards/{boardId}/columns/{columnId}/cards")
   public ResponseEntity<CommonResponseDto> createCard(@PathVariable Long boardId,
-      @PathVariable Long columnId, @RequestBody CardRequestDto cardRequestDto) {
+      @PathVariable Long columnId, @RequestBody CardRequestDto cardRequestDto,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-    // TODO: 본인이 포함되어 있는 보드인지 확인 필요
-    // TODO: ADMIN은 상관없이 통과
-
-    CardResponseDto responseDto = cardService.createdCard(cardRequestDto, boardId, columnId);
+    CardResponseDto responseDto = cardService.createdCard(cardRequestDto, boardId, columnId,
+        userDetails.getUser());
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(new CommonResponseDto(200, "카드 생성에 성공하였습니다.", responseDto));
@@ -44,12 +43,14 @@ public class CardController {
   @PutMapping("/boards/{boardId}/columns/{columnId}/cards/{cardId}")
   public ResponseEntity<CommonResponseDto> editCardContent(@PathVariable Long boardId,
       @PathVariable Long columnId, @PathVariable Long cardId,
-      @RequestBody CardRequestDto cardRequestDto) {
+      @RequestBody CardRequestDto cardRequestDto,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
     // TODO: 본인이 포함되어 있는 보드인지 확인 필요
     // TODO: 본인이 작성한 카드인지 확인 필요
     // TODO: ADMIN은 상관없이 통과
-    CardResponseDto responseDto = cardService.editCardContent(cardRequestDto, cardId);
+    CardResponseDto responseDto = cardService.editCardContent(cardRequestDto, cardId,
+        userDetails.getUser());
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(new CommonResponseDto(200, "카드 수정에 성공하였습니다.", responseDto));
@@ -57,12 +58,13 @@ public class CardController {
 
   @DeleteMapping("/boards/{boardId}/columns/{columnId}/cards/{cardId}")
   public ResponseEntity<CommonResponseDto> deleteCard(@PathVariable Long boardId,
-      @PathVariable Long columnId, @PathVariable Long cardId) {
+      @PathVariable Long columnId, @PathVariable Long cardId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
     // TODO: 본인이 포함되어 있는 보드인지 확인 필요
     // TODO: 본인이 작성한 카드인지 확인 필요
     // TODO: ADMIN은 상관없이 통과
-    cardService.deleteCard(cardId);
+    cardService.deleteCard(cardId, userDetails.getUser());
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(new CommonResponseDto(200, "카드 삭제에 성공하였습니다.", null));
@@ -70,10 +72,11 @@ public class CardController {
 
   @GetMapping("/boards/{boardId}/columns/{columnId}/cards/{cardId}")
   public ResponseEntity<CommonResponseDto> getCardDetail(@PathVariable Long boardId,
-      @PathVariable Long columnId, @PathVariable Long cardId) {
+      @PathVariable Long columnId, @PathVariable Long cardId,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
     // TODO: 본인이 포함되어 있는 보드인지 확인 필요
-    CardResponseDto responseDto = cardService.getCardDetail(cardId);
+    CardResponseDto responseDto = cardService.getCardDetail(cardId, userDetails.getUser());
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(new CommonResponseDto(200, "카드 조회에 성공하였습니다.", responseDto));
@@ -82,12 +85,14 @@ public class CardController {
   @PutMapping("/boards/{boardId}/columns/{columnId}/cards/{cardId}/tags")
   public ResponseEntity<CommonResponseDto> editCardTags(@PathVariable Long boardId,
       @PathVariable Long columnId, @PathVariable Long cardId,
-      @RequestBody CardTagEditRequestDto cardTagEditRequestDto) {
+      @RequestBody CardTagEditRequestDto cardTagEditRequestDto,
+      @AuthenticationPrincipal UserDetailsImpl userDetails) {
     // TODO: 본인이 포함되어 있는 보드인지 확인 필요
     // TODO: 본인이 작성한 카드인지 확인 필요
     // TODO: ADMIN은 상관없이 통과
 
-    CardResponseDto responseDto = cardService.editCardTags(cardId, cardTagEditRequestDto);
+    CardResponseDto responseDto = cardService.editCardTags(cardId, cardTagEditRequestDto,
+        userDetails.getUser());
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(new CommonResponseDto(200, "카드 태그 변경에 성공하였습니다.", responseDto));

--- a/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/service/CardService.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/domain/card/service/CardService.java
@@ -61,14 +61,6 @@ public class CardService {
     return new CardResponseDto(card);
   }
 
-  public List<CardResponseDto> getAllCards() {
-    List<Card> cards = cardRepository.findAll();
-
-    return cards.stream()
-        .map(card -> new CardResponseDto(card))
-        .collect(Collectors.toList());
-  }
-
   @Transactional
   public CardResponseDto editCardContent(CardRequestDto cardRequestDto, Long cardId) {
     // TODO: 유저 본인이 작성한 유저인지 확인 로직 필요

--- a/src/main/java/com/oeindevelopteam/tasknavigator/global/exception/ErrorCode.java
+++ b/src/main/java/com/oeindevelopteam/tasknavigator/global/exception/ErrorCode.java
@@ -25,7 +25,10 @@ public enum ErrorCode {
   MULTIPLE_PARAMETERS_NOT_ALLOWED(400, "여러 파라미터가 허용되지 않습니다."),
   EXPIRED_TOKEN(400, "만료된 토큰 입니다."),
   INVALID_TOKEN(400, "유효하지 않은 토큰 입니다."),
-  INVITATION_NOT_ALLOWED(400, "자신을 초대할 수 없습니다."),;
+  INVITATION_NOT_ALLOWED(400, "자신을 초대할 수 없습니다."),
+  NOT_INVITED_USER(400, "해당 보드에 초대받지 못한 유저입니다."),
+  TAG_NOT_FOUND(400, "없는 태그입니다."),
+  CARD_ACCESS_DENIED(400, "해당 카드에 대한 권한이 없습니다.");
 
   private int status;
   private String message;


### PR DESCRIPTION
## #️⃣연관된 이슈

#70 

## 📝작업 내용
- 커스텀 에러코드 추가
- 카드 기능 모두 권한 확인, 분기처리 구현
- admin만 사용할 수 있는 카드 전체 조회 api 기능 삭제
- 공통적인 로직 메서드로 분리
- 유저인지 아닌지 확인하는 로직 구현
- 보드에 초대받았는지 확인하는 로직 구현
- 본인이 작성한 카드인지 확인하는 로직 구현
- 모든 카드 기능에  적용
